### PR TITLE
[feat] #12 - 게시글 및 댓글 기능을 포함한 커뮤니티 기능 API 구현

### DIFF
--- a/src/main/java/com/interview/techview/TechviewApplication.java
+++ b/src/main/java/com/interview/techview/TechviewApplication.java
@@ -2,8 +2,10 @@ package com.interview.techview;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TechviewApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/interview/techview/config/SecurityConfig.java
+++ b/src/main/java/com/interview/techview/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -29,24 +30,34 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
-            .csrf(AbstractHttpConfigurer::disable)
-            .cors(cors -> cors.configurationSource(request -> {
-                CorsConfiguration configuration = new CorsConfiguration();
-                configuration.setAllowedOrigins(List.of(frontDomain));
-                configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                configuration.setAllowedHeaders(List.of("*"));
-                configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
-                configuration.setAllowCredentials(true);
-                return configuration;
-            }))
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 허용
-                    .requestMatchers("/error", "/api/auth/signup", "/api/auth/login", "/api/auth/refresh").permitAll()
-                    .anyRequest().authenticated()
-            )
-            // JWT 기반 인증 필터 추가
-            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(request -> {
+                    CorsConfiguration configuration = new CorsConfiguration();
+                    // 개발 환경: 여러 포트 허용
+                    configuration.setAllowedOrigins(List.of(
+                            frontDomain,
+                            "http://localhost",
+                            "http://localhost:3000",
+                            "http://localhost:5173",
+                            "http://127.0.0.1",
+                            "http://127.0.0.1:3000",
+                            "http://127.0.0.1:5173"));
+                    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+                    configuration.setAllowedHeaders(List.of("*"));
+                    configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
+                    configuration.setAllowCredentials(true);
+                    return configuration;
+                }))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll() // 게시글 조회는 누구나 접근 가능
+                        .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll() // 댓글 조회는 누구나 접근 가능
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 허용
+                        .requestMatchers("/error", "/api/auth/signup", "/api/auth/login", "/api/auth/refresh")
+                        .permitAll()
+                        .anyRequest().authenticated())
+                // JWT 기반 인증 필터 추가
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/interview/techview/controller/comment/CommentController.java
+++ b/src/main/java/com/interview/techview/controller/comment/CommentController.java
@@ -1,0 +1,90 @@
+package com.interview.techview.controller.comment;
+
+import com.interview.techview.domain.comment.Comment;
+import com.interview.techview.dto.comment.CommentCreateRequest;
+import com.interview.techview.dto.comment.CommentListResponse;
+import com.interview.techview.dto.comment.CommentPasswordRequest;
+import com.interview.techview.dto.comment.CommentResponse;
+import com.interview.techview.dto.comment.CommentUpdateRequest;
+import com.interview.techview.security.CustomUserDetails;
+import com.interview.techview.service.comment.CommentService;
+import com.interview.techview.swagger.AuthApi;
+import com.interview.techview.swagger.PublicApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Comment", description = "댓글 관리 API")
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 작성 API
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다. (인증 필요)")
+    @AuthApi
+    @PostMapping
+    public ResponseEntity<CommentResponse> addComment(
+            @Valid @RequestBody CommentCreateRequest dto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        CommentResponse comment = commentService.save(dto, userDetails.getId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(comment);
+    }
+
+    // 게시글의 댓글 목록 조회 API
+    @Operation(summary = "댓글 목록 조회", description = "특정 게시글의 모든 댓글을 조회합니다.")
+    @PublicApi
+    @GetMapping("/post/{postId}")
+    public ResponseEntity<List<CommentListResponse>> getCommentsByPostId(@PathVariable Long postId) {
+        List<CommentListResponse> commentListDto = commentService.findByPostId(postId)
+                .stream()
+                .map(CommentListResponse::from)
+                .toList();
+        return ResponseEntity.ok(commentListDto);
+    }
+
+    // 댓글 단건 조회 API
+    @Operation(summary = "댓글 단건 조회", description = "댓글 ID로 단일 댓글의 상세 정보를 조회합니다.")
+    @PublicApi
+    @GetMapping("/{id}")
+    public ResponseEntity<CommentResponse> getCommentById(@PathVariable Long id) {
+        Comment comment = commentService.findById(id);
+        return ResponseEntity.ok(CommentResponse.from(comment));
+    }
+
+    // 댓글 삭제 API
+    @Operation(summary = "댓글 삭제", description = "비밀번호를 확인하여 댓글을 삭제합니다.")
+    @PublicApi
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCommentById(
+            @PathVariable Long id,
+            @Valid @RequestBody CommentPasswordRequest dto
+    ) {
+        commentService.delete(id, dto.getPassword());
+        return ResponseEntity.ok().build();
+    }
+
+    // 댓글 수정 API
+    @Operation(summary = "댓글 수정", description = "비밀번호를 확인하여 댓글을 수정합니다.")
+    @PublicApi
+    @PutMapping("/{id}")
+    public ResponseEntity<CommentResponse> updateCommentById(
+            @PathVariable Long id,
+            @Valid @RequestBody CommentUpdateRequest dto
+    ) {
+        CommentResponse comment = commentService.update(id, dto);
+        return ResponseEntity.ok(comment);
+    }
+}
+

--- a/src/main/java/com/interview/techview/controller/post/PostBookmarkController.java
+++ b/src/main/java/com/interview/techview/controller/post/PostBookmarkController.java
@@ -1,0 +1,59 @@
+package com.interview.techview.controller.post;
+
+import com.interview.techview.dto.post.PostListResponse;
+import com.interview.techview.security.CustomUserDetails;
+import com.interview.techview.service.post.PostBookmarkService;
+import com.interview.techview.swagger.AuthApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "PostBookmark", description = "게시글 북마크 관리 API")
+@RestController
+@RequestMapping("/posts/bookmarks")
+@RequiredArgsConstructor
+public class PostBookmarkController {
+
+    private final PostBookmarkService postBookmarkService;
+
+    // 북마크 추가/삭제 API
+    @Operation(summary = "북마크 추가/삭제", description = "게시글을 북마크에 추가하거나 삭제합니다. (인증 필요)")
+    @AuthApi
+    @PostMapping("/{postId}")
+    public ResponseEntity<Void> toggleBookmark(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        postBookmarkService.toggleBookmark(postId, userDetails.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    // 북마크 목록 조회 API
+    @Operation(summary = "북마크 목록 조회", description = "사용자가 북마크한 게시글 목록을 조회합니다. (인증 필요)")
+    @AuthApi
+    @GetMapping
+    public ResponseEntity<List<PostListResponse>> getBookmarks(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<PostListResponse> bookmarks = postBookmarkService.getBookmarks(userDetails.getId());
+        return ResponseEntity.ok(bookmarks);
+    }
+
+    // 북마크 여부 확인 API
+    @Operation(summary = "북마크 여부 확인", description = "특정 게시글을 북마크했는지 확인합니다. (인증 필요)")
+    @AuthApi
+    @GetMapping("/{postId}/check")
+    public ResponseEntity<Boolean> isBookmarked(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        boolean isBookmarked = postBookmarkService.isBookmarked(postId, userDetails.getId());
+        return ResponseEntity.ok(isBookmarked);
+    }
+}
+

--- a/src/main/java/com/interview/techview/controller/post/PostController.java
+++ b/src/main/java/com/interview/techview/controller/post/PostController.java
@@ -1,0 +1,97 @@
+package com.interview.techview.controller.post;
+
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.dto.post.PostCreateRequest;
+import com.interview.techview.dto.post.PostListResponse;
+import com.interview.techview.dto.post.PostPasswordRequest;
+import com.interview.techview.dto.post.PostResponse;
+import com.interview.techview.dto.post.PostUpdateRequest;
+import com.interview.techview.security.CustomUserDetails;
+import com.interview.techview.service.post.PostService;
+import com.interview.techview.swagger.AuthApi;
+import com.interview.techview.swagger.PublicApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Post", description = "게시글 관리 API")
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+        private final PostService postService;
+
+        // 게시글 작성 API
+        @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다. (인증 필요)")
+        @AuthApi
+        @PostMapping
+        public ResponseEntity<PostResponse> addPost(
+                        @Valid @RequestBody PostCreateRequest dto,
+                        @AuthenticationPrincipal CustomUserDetails userDetails) {
+                PostResponse post = postService.save(dto, userDetails.getId());
+                return ResponseEntity.status(HttpStatus.CREATED)
+                                .body(post);
+        }
+
+        // 게시글 목록 조회 API
+        @Operation(summary = "게시글 목록 조회", description = "모든 게시글 목록을 조회합니다.")
+        @PublicApi
+        @GetMapping
+        public ResponseEntity<List<PostListResponse>> getAllPosts() {
+                List<PostListResponse> postListDto = postService.findAll()
+                                .stream()
+                                .map(PostListResponse::from)
+                                .toList();
+                return ResponseEntity.ok(postListDto);
+        }
+
+        // 게시글 단건 조회 API
+        @Operation(summary = "게시글 단건 조회", description = "게시글 ID로 단일 게시글의 상세 정보를 조회합니다.")
+        @PublicApi
+        @GetMapping("/{id}")
+        public ResponseEntity<PostResponse> getPostById(@PathVariable Long id) {
+                Post post = postService.findById(id);
+                return ResponseEntity.ok(PostResponse.from(post));
+        }
+
+        // 게시글 삭제 API
+        @Operation(summary = "게시글 삭제", description = "비밀번호를 확인하여 게시글을 삭제합니다.")
+        @PublicApi
+        @DeleteMapping("/{id}")
+        public ResponseEntity<Void> deletePostById(
+                        @PathVariable Long id,
+                        @Valid @RequestBody PostPasswordRequest dto) {
+                postService.delete(id, dto.getPassword());
+                return ResponseEntity.ok().build();
+        }
+
+        // 게시글 수정 API
+        @Operation(summary = "게시글 수정", description = "비밀번호를 확인하여 게시글을 수정합니다.")
+        @PublicApi
+        @PutMapping("/{id}")
+        public ResponseEntity<PostResponse> updatePostById(
+                        @PathVariable Long id,
+                        @Valid @RequestBody PostUpdateRequest dto) {
+                PostResponse post = postService.update(id, dto);
+                return ResponseEntity.ok(post);
+        }
+
+        // 게시글 좋아요 추가/취소 API
+        @Operation(summary = "게시글 좋아요", description = "게시글에 좋아요를 추가하거나 취소합니다. (인증 필요)")
+        @AuthApi
+        @PostMapping("/{id}/like")
+        public ResponseEntity<PostResponse> toggleLike(
+                        @PathVariable Long id,
+                        @AuthenticationPrincipal CustomUserDetails userDetails) {
+                PostResponse post = postService.toggleLike(id, userDetails.getId());
+                return ResponseEntity.ok(post);
+        }
+}

--- a/src/main/java/com/interview/techview/domain/comment/Comment.java
+++ b/src/main/java/com/interview/techview/domain/comment/Comment.java
@@ -1,0 +1,53 @@
+package com.interview.techview.domain.comment;
+
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", updatable = false)
+    private Long commentId;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "MEDIUMTEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @CreatedDate
+    @Column(name = "create_at", updatable = false)
+    private LocalDateTime createAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updateAt;
+
+    public void update(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/interview/techview/domain/post/Post.java
+++ b/src/main/java/com/interview/techview/domain/post/Post.java
@@ -1,0 +1,4 @@
+package com.interview.techview.domain.post;
+
+public class Post {
+}

--- a/src/main/java/com/interview/techview/domain/post/Post.java
+++ b/src/main/java/com/interview/techview/domain/post/Post.java
@@ -1,4 +1,73 @@
 package com.interview.techview.domain.post;
 
+import com.interview.techview.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본키를 자동으로 1씩 증가
+    @Column(name = "post_id", updatable = false)
+    private Long postId;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Lob // Large Object 긴 문자열에 사용
+    @Column(name = "content", nullable = false, columnDefinition = "MEDIUMTEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder.Default
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0; // 기본 좋아요 개수는 0개
+
+    @Builder.Default
+    @Column(name = "view_count", nullable = false)
+    private int viewCount = 0; // 기본 조회수는 0개
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @CreatedDate // 엔티티가 처음 저장될 때의 시간 자동 기록
+    @Column(name = "create_at", updatable = false)
+    private LocalDateTime createAt;
+
+    @LastModifiedDate // 엔티티가 수정될 때의 시간 자동 기록
+    @Column(name = "updated_at")
+    private LocalDateTime updateAt;
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/interview/techview/domain/post/PostBookmark.java
+++ b/src/main/java/com/interview/techview/domain/post/PostBookmark.java
@@ -1,0 +1,51 @@
+package com.interview.techview.domain.post;
+
+import com.interview.techview.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "post_bookmarks",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_bookmark",
+                        columnNames = {"user_id", "post_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_bookmark_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public PostBookmark(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}
+

--- a/src/main/java/com/interview/techview/domain/post/PostLike.java
+++ b/src/main/java/com/interview/techview/domain/post/PostLike.java
@@ -1,0 +1,41 @@
+package com.interview.techview.domain.post;
+
+import com.interview.techview.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "post_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_like",
+                        columnNames = {"user_id", "post_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    public PostLike(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}
+

--- a/src/main/java/com/interview/techview/dto/comment/CommentCreateRequest.java
+++ b/src/main/java/com/interview/techview/dto/comment/CommentCreateRequest.java
@@ -1,0 +1,42 @@
+package com.interview.techview.dto.comment;
+
+import com.interview.techview.domain.comment.Comment;
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "댓글 생성 요청 DTO")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CommentCreateRequest {
+
+    @Schema(description = "댓글 내용", example = "좋은 글 감사합니다!")
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String content;
+
+    @Schema(description = "게시글 ID", example = "1")
+    @NotNull(message = "게시글 ID는 필수입니다.")
+    private Long postId;
+
+    @Schema(description = "댓글 비밀번호", example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 작성해주세요.")
+    private String password;
+
+    public Comment toEntity(Post post, User user, String hashedPassword) {
+        return Comment.builder()
+                .content(content)
+                .post(post)
+                .user(user)
+                .password(hashedPassword)
+                .build();
+    }
+}
+

--- a/src/main/java/com/interview/techview/dto/comment/CommentListResponse.java
+++ b/src/main/java/com/interview/techview/dto/comment/CommentListResponse.java
@@ -1,0 +1,42 @@
+package com.interview.techview.dto.comment;
+
+import com.interview.techview.domain.comment.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "댓글 목록 응답 DTO")
+@Getter
+@Builder
+public class CommentListResponse {
+
+    @Schema(description = "댓글 ID", example = "1")
+    private Long commentId;
+
+    @Schema(description = "댓글 내용")
+    private String content;
+
+    @Schema(description = "작성자 이름")
+    private String userName;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createAt;
+
+    public static CommentListResponse from(Comment comment) {
+        if (comment == null) {
+            throw new IllegalArgumentException("Comment cannot be null");
+        }
+
+        String userName = comment.getUser() != null ? comment.getUser().getName() : "Unknown";
+
+        return CommentListResponse.builder()
+                .commentId(comment.getCommentId())
+                .content(comment.getContent())
+                .userName(userName)
+                .createAt(comment.getCreateAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/interview/techview/dto/comment/CommentPasswordRequest.java
+++ b/src/main/java/com/interview/techview/dto/comment/CommentPasswordRequest.java
@@ -1,0 +1,21 @@
+package com.interview.techview.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "댓글 비밀번호 확인 요청 DTO")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentPasswordRequest {
+
+    @Schema(description = "댓글 비밀번호", example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 작성해주세요.")
+    private String password;
+}
+

--- a/src/main/java/com/interview/techview/dto/comment/CommentResponse.java
+++ b/src/main/java/com/interview/techview/dto/comment/CommentResponse.java
@@ -1,0 +1,51 @@
+package com.interview.techview.dto.comment;
+
+import com.interview.techview.domain.comment.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "댓글 응답 DTO")
+@Getter
+@Builder
+public class CommentResponse {
+
+    @Schema(description = "댓글 ID", example = "1")
+    private Long commentId;
+
+    @Schema(description = "댓글 내용")
+    private String content;
+
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "작성자 이름")
+    private String userName;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createAt;
+
+    @Schema(description = "수정일시")
+    private LocalDateTime updateAt;
+
+    public static CommentResponse from(Comment comment) {
+        if (comment == null) {
+            throw new IllegalArgumentException("Comment cannot be null");
+        }
+
+        String userName = comment.getUser() != null ? comment.getUser().getName() : "Unknown";
+        Long postId = comment.getPost() != null ? comment.getPost().getPostId() : null;
+
+        return CommentResponse.builder()
+                .commentId(comment.getCommentId())
+                .content(comment.getContent())
+                .postId(postId)
+                .userName(userName)
+                .createAt(comment.getCreateAt())
+                .updateAt(comment.getUpdateAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/interview/techview/dto/comment/CommentUpdateRequest.java
+++ b/src/main/java/com/interview/techview/dto/comment/CommentUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.interview.techview.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "댓글 수정 요청 DTO")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentUpdateRequest {
+
+    @Schema(description = "댓글 내용", example = "수정된 댓글 내용")
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String content;
+
+    @Schema(description = "댓글 비밀번호", example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 작성해주세요.")
+    private String password;
+}
+

--- a/src/main/java/com/interview/techview/dto/post/PostCreateRequest.java
+++ b/src/main/java/com/interview/techview/dto/post/PostCreateRequest.java
@@ -1,0 +1,40 @@
+package com.interview.techview.dto.post;
+
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "게시글 생성 요청 DTO")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class PostCreateRequest {
+
+    @Schema(description = "게시글 제목", example = "Spring Boot 기초")
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 200, message = "제목은 200자 이하로 작성해주세요.")
+    private String title;
+
+    @Schema(description = "게시글 내용", example = "Spring Boot에 대해 설명합니다.")
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    @Schema(description = "게시글 비밀번호", example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 작성해주세요.")
+    private String password;
+
+    public Post toEntity(User user, String hashedPassword) {
+        return Post.builder()
+                .title(title)
+                .content(content)
+                .user(user)
+                .password(hashedPassword)
+                .build();
+    }
+}

--- a/src/main/java/com/interview/techview/dto/post/PostListResponse.java
+++ b/src/main/java/com/interview/techview/dto/post/PostListResponse.java
@@ -1,0 +1,43 @@
+package com.interview.techview.dto.post;
+
+import com.interview.techview.domain.post.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "게시글 목록 응답 DTO")
+@Getter
+@Builder
+public class PostListResponse {
+
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "게시글 제목")
+    private String title;
+
+    @Schema(description = "작성자 이름")
+    private String name;
+
+    @Schema(description = "좋아요 개수", example = "0")
+    private int likeCount;
+
+    @Schema(description = "조회수", example = "0")
+    private int viewCount;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createAt;
+
+    public static PostListResponse from(Post post) {
+        return PostListResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .name(post.getUser().getName())
+                .likeCount(post.getLikeCount())
+                .viewCount(post.getViewCount())
+                .createAt(post.getCreateAt())
+                .build();
+    }
+}

--- a/src/main/java/com/interview/techview/dto/post/PostPasswordRequest.java
+++ b/src/main/java/com/interview/techview/dto/post/PostPasswordRequest.java
@@ -1,0 +1,20 @@
+package com.interview.techview.dto.post;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "게시글 비밀번호 확인 요청 DTO")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPasswordRequest {
+
+    @Schema(description = "게시글 비밀번호", example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 작성해주세요.")
+    private String password;
+}

--- a/src/main/java/com/interview/techview/dto/post/PostResponse.java
+++ b/src/main/java/com/interview/techview/dto/post/PostResponse.java
@@ -1,0 +1,58 @@
+package com.interview.techview.dto.post;
+
+import com.interview.techview.domain.post.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "게시글 응답 DTO")
+@Getter
+@Builder
+public class PostResponse {
+
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "게시글 제목")
+    private String title;
+
+    @Schema(description = "게시글 내용")
+    private String content;
+
+    @Schema(description = "작성자 이름")
+    private String name;
+
+    @Schema(description = "좋아요 개수", example = "0")
+    private int likeCount;
+
+    @Schema(description = "조회수", example = "0")
+    private int viewCount;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createAt;
+
+    @Schema(description = "수정일시")
+    private LocalDateTime updateAt;
+
+    public static PostResponse from(Post post) {
+        if (post == null) {
+            throw new IllegalArgumentException("Post cannot be null");
+        }
+        
+        String userName = post.getUser() != null ? post.getUser().getName() : "Unknown";
+        
+        return PostResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .name(userName)
+                .likeCount(post.getLikeCount())
+                .viewCount(post.getViewCount())
+                .createAt(post.getCreateAt())
+                .updateAt(post.getUpdateAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/interview/techview/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/interview/techview/dto/post/PostUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.interview.techview.dto.post;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "게시글 수정 요청 DTO")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostUpdateRequest {
+
+    @Schema(description = "게시글 제목", example = "수정된 제목")
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 200, message = "제목은 200자 이하로 작성해주세요.")
+    private String title;
+
+    @Schema(description = "게시글 내용", example = "수정된 내용")
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    @Schema(description = "게시글 비밀번호", example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상 20자 이하로 작성해주세요.")
+    private String password;
+}
+

--- a/src/main/java/com/interview/techview/exception/ErrorCode.java
+++ b/src/main/java/com/interview/techview/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIAL(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
 
     // 403 Forbidden
@@ -26,6 +27,8 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리포트를 찾을 수 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/interview/techview/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/interview/techview/exception/GlobalExceptionHandler.java
@@ -9,12 +9,25 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/**
+ * 전역 예외 처리 클래스
+ * 
+ * 애플리케이션 전역에서 발생하는 예외를 한 곳에서 처리하여
+ * 일관된 에러 응답을 제공합니다.
+ * 
+ * @RestControllerAdvice: 모든 컨트롤러에서 발생하는 예외를 처리
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    // CustomException 처리
+    /**
+     * CustomException 처리
+     * 
+     * 비즈니스 로직에서 발생하는 커스텀 예외를 처리합니다.
+     * ErrorCode에 정의된 상태 코드와 메시지를 응답합니다.
+     */
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
@@ -23,7 +36,15 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(errorCode));
     }
 
-    // @Valid 검증 실패 처리
+    /**
+     * @Valid 검증 실패 처리
+     * 
+     * DTO에 @Valid 어노테이션이 적용된 파라미터의 유효성 검사가 실패했을 때
+     * MethodArgumentNotValidException이 발생하며, 이를 처리합니다.
+     * 
+     * 모든 검증 실패 메시지를 수집하여 응답에 포함시킵니다.
+     * 예: "제목은 필수입니다.", "비밀번호는 6자 이상 20자 이하로 작성해주세요."
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
         List<String> messages = e.getBindingResult()
@@ -37,7 +58,12 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, messages));
     }
 
-    // 모든 예상 못 한 예외 처리
+    /**
+     * 모든 예상치 못한 예외 처리
+     * 
+     * 위에서 처리하지 못한 모든 예외를 처리합니다.
+     * 로그를 기록하고 500 Internal Server Error를 응답합니다.
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Unhandled exception occurred", e);

--- a/src/main/java/com/interview/techview/exception/comment/CommentNotFoundException.java
+++ b/src/main/java/com/interview/techview/exception/comment/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.interview.techview.exception.comment;
+
+import com.interview.techview.exception.CustomException;
+import com.interview.techview.exception.ErrorCode;
+
+public class CommentNotFoundException extends CustomException {
+    public CommentNotFoundException() {
+        super(ErrorCode.COMMENT_NOT_FOUND);
+    }
+}
+

--- a/src/main/java/com/interview/techview/exception/post/PasswordMismatchException.java
+++ b/src/main/java/com/interview/techview/exception/post/PasswordMismatchException.java
@@ -1,0 +1,15 @@
+package com.interview.techview.exception.post;
+
+import com.interview.techview.exception.CustomException;
+import com.interview.techview.exception.ErrorCode;
+
+/**
+ * 게시글 비밀번호가 일치하지 않을 때 발생하는 예외
+ */
+public class PasswordMismatchException extends CustomException {
+
+    public PasswordMismatchException() {
+        super(ErrorCode.PASSWORD_MISMATCH);
+    }
+}
+

--- a/src/main/java/com/interview/techview/exception/post/PostNotFoundException.java
+++ b/src/main/java/com/interview/techview/exception/post/PostNotFoundException.java
@@ -1,0 +1,15 @@
+package com.interview.techview.exception.post;
+
+import com.interview.techview.exception.CustomException;
+import com.interview.techview.exception.ErrorCode;
+
+/**
+ * 게시글을 찾을 수 없을 때 발생하는 예외
+ */
+public class PostNotFoundException extends CustomException {
+
+    public PostNotFoundException() {
+        super(ErrorCode.POST_NOT_FOUND);
+    }
+}
+

--- a/src/main/java/com/interview/techview/repository/comment/CommentRepository.java
+++ b/src/main/java/com/interview/techview/repository/comment/CommentRepository.java
@@ -1,0 +1,19 @@
+package com.interview.techview.repository.comment;
+
+import com.interview.techview.domain.comment.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(attributePaths = {"user", "post"})
+    List<Comment> findByPost_PostId(Long postId);
+
+    @EntityGraph(attributePaths = {"user", "post"})
+    @Override
+    Optional<Comment> findById(Long id);
+}
+

--- a/src/main/java/com/interview/techview/repository/post/PostBookmarkRepository.java
+++ b/src/main/java/com/interview/techview/repository/post/PostBookmarkRepository.java
@@ -1,0 +1,19 @@
+package com.interview.techview.repository.post;
+
+import com.interview.techview.domain.post.PostBookmark;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostBookmarkRepository extends JpaRepository<PostBookmark, Long> {
+    @EntityGraph(attributePaths = {"post.user"})
+    List<PostBookmark> findByUser_Id(Long userId);
+    
+    Optional<PostBookmark> findByUser_IdAndPost_PostId(Long userId, Long postId);
+    boolean existsByUser_IdAndPost_PostId(Long userId, Long postId);
+    void deleteByUser_IdAndPost_PostId(Long userId, Long postId);
+    void deleteByPost_PostId(Long postId); // 게시글 삭제 시 모든 북마크 삭제
+}
+

--- a/src/main/java/com/interview/techview/repository/post/PostLikeRepository.java
+++ b/src/main/java/com/interview/techview/repository/post/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package com.interview.techview.repository.post;
+
+import com.interview.techview.domain.post.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByUser_IdAndPost_PostId(Long userId, Long postId);
+    boolean existsByUser_IdAndPost_PostId(Long userId, Long postId);
+    void deleteByUser_IdAndPost_PostId(Long userId, Long postId);
+    void deleteByPost_PostId(Long postId); // 게시글 삭제 시 모든 좋아요 삭제
+}
+

--- a/src/main/java/com/interview/techview/repository/post/PostQueryRepository.java
+++ b/src/main/java/com/interview/techview/repository/post/PostQueryRepository.java
@@ -1,0 +1,14 @@
+package com.interview.techview.repository.post;
+
+import com.interview.techview.domain.post.Post;
+
+import java.util.List;
+
+public interface PostQueryRepository {
+    // 예시: 제목으로 게시글 검색
+    List<Post> searchByTitle(String keyword);
+    
+    // 예시: 특정 사용자의 게시글 조회
+    List<Post> findByUserId(Long userId);
+}
+

--- a/src/main/java/com/interview/techview/repository/post/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/interview/techview/repository/post/PostQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.interview.techview.repository.post;
+
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.post.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostQueryRepositoryImpl implements PostQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Post> searchByTitle(String keyword) {
+        QPost post = QPost.post;
+
+        return queryFactory
+                .selectFrom(post)
+                .leftJoin(post.user).fetchJoin() // user를 함께 조회
+                .where(post.title.contains(keyword))
+                .orderBy(post.createAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Post> findByUserId(Long userId) {
+        QPost post = QPost.post;
+
+        return queryFactory
+                .selectFrom(post)
+                .leftJoin(post.user).fetchJoin() // user를 함께 조회
+                .where(post.user.id.eq(userId))
+                .orderBy(post.createAt.desc())
+                .fetch();
+    }
+}
+

--- a/src/main/java/com/interview/techview/repository/post/PostRepository.java
+++ b/src/main/java/com/interview/techview/repository/post/PostRepository.java
@@ -1,0 +1,19 @@
+package com.interview.techview.repository.post;
+
+import com.interview.techview.domain.post.Post;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
+
+    @EntityGraph(attributePaths = { "user" })
+    @Override
+    List<Post> findAll();
+
+    @EntityGraph(attributePaths = { "user" })
+    @Override
+    Optional<Post> findById(Long id);
+}

--- a/src/main/java/com/interview/techview/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/interview/techview/security/JwtAuthenticationFilter.java
@@ -22,15 +22,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final CustomUserDetailsService userDetailsService;
 
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
-                                   CustomUserDetailsService userDetailsService) {
+            CustomUserDetailsService userDetailsService) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.userDetailsService = userDetailsService;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain)
+            HttpServletResponse response,
+            FilterChain filterChain)
             throws ServletException, IOException {
 
         String token = resolveToken(request);
@@ -43,12 +43,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 UserDetails userDetails = userDetailsService.loadUserById(userId);
 
-                UsernamePasswordAuthenticationToken auth =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails,
-                                null,
-                                userDetails.getAuthorities()
-                        );
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities());
 
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
@@ -87,6 +85,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        // GET 요청으로 게시글 조회하는 경우 제외
+        if ("GET".equals(method) && matcher.match("/api/posts/**", path)) {
+            return true;
+        }
+
+        // GET 요청으로 댓글 조회하는 경우 제외
+        if ("GET".equals(method) && matcher.match("/api/comments/**", path)) {
+            return true;
+        }
+
         for (String p : EXCLUDED) {
             if (matcher.match(p, path)) {
                 return true;

--- a/src/main/java/com/interview/techview/service/comment/CommentService.java
+++ b/src/main/java/com/interview/techview/service/comment/CommentService.java
@@ -1,0 +1,93 @@
+package com.interview.techview.service.comment;
+
+import com.interview.techview.domain.comment.Comment;
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.user.User;
+import com.interview.techview.dto.comment.CommentCreateRequest;
+import com.interview.techview.dto.comment.CommentResponse;
+import com.interview.techview.dto.comment.CommentUpdateRequest;
+import com.interview.techview.exception.CustomException;
+import com.interview.techview.exception.ErrorCode;
+import com.interview.techview.exception.comment.CommentNotFoundException;
+import com.interview.techview.exception.post.PasswordMismatchException;
+import com.interview.techview.exception.post.PostNotFoundException;
+import com.interview.techview.repository.comment.CommentRepository;
+import com.interview.techview.repository.post.PostRepository;
+import com.interview.techview.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 댓글 작성
+    @Transactional
+    public CommentResponse save(CommentCreateRequest dto, Long userId) {
+        Post post = postRepository.findById(dto.getPostId())
+                .orElseThrow(PostNotFoundException::new);
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        
+        String hashedPassword = passwordEncoder.encode(dto.getPassword());
+        Comment savedComment = commentRepository.save(dto.toEntity(post, user, hashedPassword));
+        
+        // 저장 후 EntityGraph를 사용하여 user와 post를 함께 조회
+        Comment comment = commentRepository.findById(savedComment.getCommentId())
+                .orElseThrow(CommentNotFoundException::new);
+        
+        return CommentResponse.from(comment);
+    }
+
+    // 게시글의 댓글 목록 조회
+    @Transactional(readOnly = true)
+    public List<Comment> findByPostId(Long postId) {
+        return commentRepository.findByPost_PostId(postId);
+    }
+
+    // 댓글 단건 조회
+    @Transactional(readOnly = true)
+    public Comment findById(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(CommentNotFoundException::new);
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public void delete(Long id, String inputPassword) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(CommentNotFoundException::new);
+
+        if (!passwordEncoder.matches(inputPassword, comment.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        commentRepository.delete(comment);
+    }
+
+    // 댓글 수정
+    @Transactional
+    public CommentResponse update(Long id, CommentUpdateRequest dto) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(CommentNotFoundException::new);
+
+        if (!passwordEncoder.matches(dto.getPassword(), comment.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        comment.update(dto.getContent());
+        return CommentResponse.from(comment);
+    }
+}
+

--- a/src/main/java/com/interview/techview/service/post/PostBookmarkService.java
+++ b/src/main/java/com/interview/techview/service/post/PostBookmarkService.java
@@ -1,0 +1,64 @@
+package com.interview.techview.service.post;
+
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.post.PostBookmark;
+import com.interview.techview.domain.user.User;
+import com.interview.techview.dto.post.PostListResponse;
+import com.interview.techview.exception.CustomException;
+import com.interview.techview.exception.ErrorCode;
+import com.interview.techview.exception.post.PostNotFoundException;
+import com.interview.techview.repository.post.PostBookmarkRepository;
+import com.interview.techview.repository.post.PostRepository;
+import com.interview.techview.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostBookmarkService {
+
+    private final PostBookmarkRepository postBookmarkRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    // 북마크 추가/삭제
+    @Transactional
+    public void toggleBookmark(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        boolean isBookmarked = postBookmarkRepository.existsByUser_IdAndPost_PostId(userId, postId);
+
+        if (isBookmarked) {
+            // 북마크 삭제
+            postBookmarkRepository.deleteByUser_IdAndPost_PostId(userId, postId);
+        } else {
+            // 북마크 추가
+            PostBookmark bookmark = new PostBookmark(user, post);
+            postBookmarkRepository.save(bookmark);
+        }
+    }
+
+    // 사용자의 북마크 목록 조회
+    @Transactional(readOnly = true)
+    public List<PostListResponse> getBookmarks(Long userId) {
+        List<PostBookmark> bookmarks = postBookmarkRepository.findByUser_Id(userId);
+        return bookmarks.stream()
+                .map(bookmark -> PostListResponse.from(bookmark.getPost()))
+                .toList();
+    }
+
+    // 북마크 여부 확인
+    @Transactional(readOnly = true)
+    public boolean isBookmarked(Long postId, Long userId) {
+        return postBookmarkRepository.existsByUser_IdAndPost_PostId(userId, postId);
+    }
+}
+

--- a/src/main/java/com/interview/techview/service/post/PostService.java
+++ b/src/main/java/com/interview/techview/service/post/PostService.java
@@ -1,0 +1,139 @@
+package com.interview.techview.service.post;
+
+import com.interview.techview.domain.post.Post;
+import com.interview.techview.domain.post.PostLike;
+import com.interview.techview.domain.user.User;
+import com.interview.techview.dto.post.PostCreateRequest;
+import com.interview.techview.dto.post.PostResponse;
+import com.interview.techview.dto.post.PostUpdateRequest;
+import com.interview.techview.exception.CustomException;
+import com.interview.techview.exception.ErrorCode;
+import com.interview.techview.exception.post.PasswordMismatchException;
+import com.interview.techview.exception.post.PostNotFoundException;
+import com.interview.techview.repository.comment.CommentRepository;
+import com.interview.techview.repository.post.PostBookmarkRepository;
+import com.interview.techview.repository.post.PostLikeRepository;
+import com.interview.techview.repository.post.PostRepository;
+import com.interview.techview.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostBookmarkRepository postBookmarkRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 게시글 작성
+    @Transactional
+    public PostResponse save(PostCreateRequest dto, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String hashedPassword = passwordEncoder.encode(dto.getPassword());
+        Post savedPost = postRepository.save(dto.toEntity(user, hashedPassword));
+
+        // 저장 후 EntityGraph를 사용하여 user를 함께 조회하여 Lazy Loading 문제 방지
+        Post post = postRepository.findById(savedPost.getPostId())
+                .orElseThrow(PostNotFoundException::new);
+
+        return PostResponse.from(post);
+    }
+
+    // 게시글 전체 조회
+    @Transactional(readOnly = true)
+    public List<Post> findAll() {
+        return postRepository.findAll();
+    }
+
+    // 게시글 단건 조회 (조회수 증가)
+    @Transactional
+    public Post findById(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+
+        // 조회수 증가
+        post.incrementViewCount();
+
+        return post;
+    }
+
+    // 게시글 삭제
+    @Transactional
+    public void delete(Long id, String inputPassword) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+
+        // 입력 받은 password와 게시글에 저장된 password를 비교
+        if (!passwordEncoder.matches(inputPassword, post.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        // 게시글 삭제 전에 관련 데이터 먼저 삭제 (외래키 제약조건 해결)
+        // 1. 댓글 삭제
+        commentRepository.deleteAll(commentRepository.findByPost_PostId(id));
+
+        // 2. 좋아요 삭제
+        postLikeRepository.deleteByPost_PostId(id);
+
+        // 3. 북마크 삭제
+        postBookmarkRepository.deleteByPost_PostId(id);
+
+        // 4. 게시글 삭제
+        postRepository.delete(post);
+    }
+
+    // 게시글 수정
+    @Transactional
+    public PostResponse update(Long id, PostUpdateRequest dto) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+
+        // 입력 받은 password와 게시글에 저장된 password를 비교
+        if (!passwordEncoder.matches(dto.getPassword(), post.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        post.update(dto.getTitle(), dto.getContent());
+        return PostResponse.from(post);
+    }
+
+    // 게시글 좋아요 추가/취소
+    @Transactional
+    public PostResponse toggleLike(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        boolean isLiked = postLikeRepository.existsByUser_IdAndPost_PostId(userId, postId);
+
+        if (isLiked) {
+            // 좋아요 취소
+            postLikeRepository.deleteByUser_IdAndPost_PostId(userId, postId);
+            post.decrementLikeCount();
+        } else {
+            // 좋아요 추가
+            PostLike postLike = new PostLike(user, post);
+            postLikeRepository.save(postLike);
+            post.incrementLikeCount();
+        }
+
+        // 업데이트된 Post 조회
+        Post updatedPost = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+
+        return PostResponse.from(updatedPost);
+    }
+}


### PR DESCRIPTION
## 📌 Summary

게시글(Post) 및 댓글(Comment) 기능을 포함한 커뮤니티 기능을 구현했습니다. 게시글 CRUD, 댓글 CRUD, 좋아요, 북마크, 조회수 기능을 제공하며, 비밀번호 기반 인증과 JWT 인증을 통합하여 보안을 강화했습니다.

## ✍️ Description

게시글과 댓글 기능을 중심으로 한 커뮤니티 기능을 구현했습니다. 주요 기능은 다음과 같습니다:

### 구현된 기능

1. **게시글 CRUD API**
   - 게시글 작성 (JWT 인증 필요)
   - 게시글 목록 조회 (인증 불필요)
   - 게시글 단건 조회 (인증 불필요)
   - 게시글 수정 (비밀번호 확인)
   - 게시글 삭제 (비밀번호 확인)

2. **댓글 CRUD API**
   - 댓글 작성 (JWT 인증 필요)
   - 게시글별 댓글 목록 조회 (인증 불필요)
   - 댓글 단건 조회 (인증 불필요)
   - 댓글 수정 (비밀번호 확인, 작성자만 가능)
   - 댓글 삭제 (비밀번호 확인, 작성자만 가능)

3. **좋아요 기능**
   - 게시글 좋아요 추가/취소 (토글 방식)
   - 좋아요 개수 자동 업데이트

4. **북마크 기능**
   - 게시글 북마크 추가/삭제 (토글 방식)
   - 사용자별 북마크 목록 조회
   - 북마크 여부 확인

5. **조회수 기능**
   - 게시글 단건 조회 시 조회수 자동 증가
   - 목록 조회에서는 조회수 증가하지 않음

### 기술적 구현 사항

- **엔티티 설계**: Post, Comment, PostLike, PostBookmark 엔티티 생성
- **관계 설정**: User와 Post, Post와 Comment 간 Many-to-One 관계
- **외래키 제약조건**: 게시글 삭제 시 관련 데이터(댓글, 좋아요, 북마크) 자동 삭제 처리
- **JPA Auditing**: `@CreatedDate`, `@LastModifiedDate`를 통한 자동 시간 기록
- **보안**: 비밀번호 BCrypt 암호화, JWT 인증 통합
- **예외 처리**: 커스텀 예외 클래스 및 전역 예외 핸들러 구현
- **DTO 패턴**: 요청/응답 DTO 분리 및 유효성 검증 적용

- close: #12

## 💡 PR Point

### 1. 외래키 제약조건 처리
게시글 삭제 시 `post_likes`, `post_bookmarks`, `comments` 테이블의 외래키 제약조건으로 인한 오류를 해결하기 위해, 게시글 삭제 전에 관련 데이터를 먼저 삭제하는 순서를 보장했습니다.

```java
// 게시글 삭제 전에 관련 데이터 먼저 삭제
commentRepository.deleteAll(commentRepository.findByPost_PostId(id));
postLikeRepository.deleteByPost_PostId(id);
postBookmarkRepository.deleteByPost_PostId(id);
postRepository.delete(post);
```

### 2. 조회수 증가 로직
조회수는 단건 조회 시에만 증가하도록 구현했습니다. 목록 조회에서는 조회수가 증가하지 않으며, `findById()` 메서드를 `@Transactional`로 변경하여 조회수 증가를 반영했습니다.

### 3. 좋아요/북마크 토글 방식
사용자가 이미 좋아요/북마크를 눌렀는지 확인하여 추가/삭제를 자동으로 처리하는 토글 방식으로 구현했습니다. 중복 방지를 위해 DB 유니크 제약조건을 설정했습니다.

### 4. 인증 및 권한 관리
- 게시글/댓글 작성: JWT 인증 필요
- 게시글/댓글 조회: 인증 불필요 (공개)
- 게시글/댓글 수정/삭제: 비밀번호 확인 + 작성자 확인 (댓글의 경우)

### 5. Lazy Loading 방지
`@EntityGraph`를 사용하여 N+1 문제를 방지하고, 필요한 연관 엔티티를 함께 조회하도록 최적화했습니다.

## 📚 Reference 

- Spring Data JPA Entity Graph: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.entity-graph
- JWT Authentication: Spring Security JWT 구현 패턴
- BCrypt Password Encoding: Spring Security PasswordEncoder

## 🔥 Test
<img width="1180" height="598" alt="스크린샷 2025-12-17 오전 12 13 25" src="https://github.com/user-attachments/assets/d72c1c5e-673b-4978-af16-a05ff2814a95" />
<img width="1171" height="184" alt="스크린샷 2025-12-17 오전 12 14 07" src="https://github.com/user-attachments/assets/cbcb3726-6364-4d17-b87a-3cad982a8a4f" />


## 📝 PR Comment

### 주요 변경사항
- 새로운 엔티티: `Post`, `Comment`, `PostLike`, `PostBookmark`
- 새로운 컨트롤러: `PostController`, `CommentController`, `PostBookmarkController`
- 새로운 서비스: `PostService`, `CommentService`, `PostBookmarkService`
- 새로운 Repository: `PostRepository`, `CommentRepository`, `PostLikeRepository`, `PostBookmarkRepository`
- DTO 클래스: 요청/응답 DTO 다수 추가
- 예외 처리: `PostNotFoundException`, `CommentNotFoundException`, `PasswordMismatchException` 추가

### 데이터베이스 변경사항
- `Post` 테이블: `view_count` 컬럼 추가
- `Comment` 테이블: 새로 생성
- `post_likes` 테이블: 새로 생성
- `post_bookmarks` 테이블: 새로 생성

### 보안 설정 변경
- `SecurityConfig`: 게시글/댓글 조회는 인증 불필요하도록 설정
- `JwtAuthenticationFilter`: GET 요청은 JWT 검증 제외

---

**주의사항**: 
- 데이터베이스 스키마가 자동으로 업데이트됩니다 (`ddl-auto=update`)
- 기존 데이터가 있는 경우 마이그레이션 주의 필요

